### PR TITLE
Allow saving results in st2 key/value store

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Change Log
+## 0.3.0
+- Added ability to save results into st2 key/value store. Useful when the result from Netbox is very large and will be piped to another action.
 ## 0.2.1
 - Added `role` to dcim_get_devices
 ## 0.2.0

--- a/actions/base_get_action.py
+++ b/actions/base_get_action.py
@@ -23,8 +23,8 @@ class NetboxBaseGetAction(NetboxBaseAction):
             # save the result in the st2 keystore
             client = Client(base_url='http://localhost')
             key_name = kwargs['save_in_key_store_key_name']
-            client.keys.update(KeyValuePair(name=key_name, value=json.dumps(result)),
-                               ttl=kwargs['save_in_key_store_ttl'])
+            client.keys.update(KeyValuePair(name=key_name, value=json.dumps(result),
+                                            ttl=kwargs['save_in_key_store_ttl']))
 
             return (True, "Result stored in st2 key {}".format(key_name))
 

--- a/actions/base_get_action.py
+++ b/actions/base_get_action.py
@@ -1,5 +1,9 @@
 
+import json
+
 from lib.action import NetboxBaseAction
+from st2client.client import Client
+from st2client.models import KeyValuePair
 
 
 class NetboxBaseGetAction(NetboxBaseAction):
@@ -9,4 +13,19 @@ class NetboxBaseGetAction(NetboxBaseAction):
         """Base get action
         endpoint_uri is pased from metadata file
         """
+
+        if kwargs.get('save_in_key_store') and not kwargs.get('save_in_key_store_key_name'):
+            return (False, 'save_in_key_store_key_name MUST be used with save_in_key_store!')
+
+        result = self.get(endpoint_uri, **kwargs)
+
+        if kwargs['save_in_key_store']:
+            # save the result in the st2 keystore
+            client = Client(base_url='http://localhost')
+            key_name = kwargs['save_in_key_store_key_name']
+            client.keys.update(KeyValuePair(name=key_name, value=json.dumps(result)),
+                               ttl=kwargs['save_in_key_store_ttl'])
+
+            return (True, "Result stored in st2 key {}".format(key_name))
+
         return self.get(endpoint_uri, **kwargs)

--- a/actions/dcim_get_devices.yaml
+++ b/actions/dcim_get_devices.yaml
@@ -95,3 +95,14 @@ parameters:
     type: integer
     default: 0
     description: Offset result set by X objects. Used for pagination.
+  save_in_keystore:
+    type: boolean
+    default: false
+    description: Save the result of the action as a json object in the st2 keystore. Used when the expected result from Netbox is very large and the result will be piped to another action. You must also specify a save_in_keystore_keyname and an optional save_in_keystore_ttl.
+  save_in_keystore_keyname:
+    type: string
+    description: Name of the key to store the json result value in the st2 keystore. Must be used with save_in_keystore and optionally save_in_keystore_ttl.
+  save_in_keystore_ttl:
+    type: integer
+    default: 60
+    description: TTL (seconds) of the saved json result in the st2 keystore. Defaults to 60 seconds. Must be used with save_in_keystore and save_in_keystore_keyname.

--- a/actions/dcim_get_devices.yaml
+++ b/actions/dcim_get_devices.yaml
@@ -95,14 +95,14 @@ parameters:
     type: integer
     default: 0
     description: Offset result set by X objects. Used for pagination.
-  save_in_keystore:
+  save_in_key_store:
     type: boolean
     default: false
-    description: Save the result of the action as a json object in the st2 keystore. Used when the expected result from Netbox is very large and the result will be piped to another action. You must also specify a save_in_keystore_keyname and an optional save_in_keystore_ttl.
-  save_in_keystore_keyname:
+    description: Save the result of the action as a json object in the st2 key store. Used when the expected result from Netbox is very large and the result will be piped to another action. You must also specify a save_in_key_store_keyname and an optional save_in_key_store_ttl.
+  save_in_key_store_key_name:
     type: string
-    description: Name of the key to store the json result value in the st2 keystore. Must be used with save_in_keystore and optionally save_in_keystore_ttl.
-  save_in_keystore_ttl:
+    description: Name of the key to store the json result value in the st2 key store. Must be used with save_in_key_store and optionally save_in_key_store_ttl.
+  save_in_key_store_ttl:
     type: integer
     default: 60
-    description: TTL (seconds) of the saved json result in the st2 keystore. Defaults to 60 seconds. Must be used with save_in_keystore and save_in_keystore_keyname.
+    description: TTL (seconds) of the saved json result in the st2 key store. Defaults to 60 seconds. Must be used with save_in_key_store and save_in_key_store_key_name.

--- a/actions/dcim_get_interfaces.yaml
+++ b/actions/dcim_get_interfaces.yaml
@@ -35,3 +35,14 @@ parameters:
     type: integer
     default: 0
     description: Offset result set by X objects. Used for pagination.
+  save_in_key_store:
+    type: boolean
+    default: false
+    description: Save the result of the action as a json object in the st2 key store. Used when the expected result from Netbox is very large and the result will be piped to another action. You must also specify a save_in_key_store_keyname and an optional save_in_key_store_ttl.
+  save_in_key_store_key_name:
+    type: string
+    description: Name of the key to store the json result value in the st2 key store. Must be used with save_in_key_store and optionally save_in_key_store_ttl.
+  save_in_key_store_ttl:
+    type: integer
+    default: 60
+    description: TTL (seconds) of the saved json result in the st2 key store. Defaults to 60 seconds. Must be used with save_in_key_store and save_in_key_store_key_name.

--- a/actions/dcim_get_sites.yaml
+++ b/actions/dcim_get_sites.yaml
@@ -44,3 +44,14 @@ parameters:
     type: integer
     default: 0
     description: Offset result set by X objects. Used for pagination.
+  save_in_key_store:
+    type: boolean
+    default: false
+    description: Save the result of the action as a json object in the st2 key store. Used when the expected result from Netbox is very large and the result will be piped to another action. You must also specify a save_in_key_store_keyname and an optional save_in_key_store_ttl.
+  save_in_key_store_key_name:
+    type: string
+    description: Name of the key to store the json result value in the st2 key store. Must be used with save_in_key_store and optionally save_in_key_store_ttl.
+  save_in_key_store_ttl:
+    type: integer
+    default: 60
+    description: TTL (seconds) of the saved json result in the st2 key store. Defaults to 60 seconds. Must be used with save_in_key_store and save_in_key_store_key_name.

--- a/actions/ipam_get_available_ips.yaml
+++ b/actions/ipam_get_available_ips.yaml
@@ -20,4 +20,14 @@ parameters:
     type: integer
     default: 0
     description: Offset result set by X objects. Used for pagination.
-
+  save_in_key_store:
+    type: boolean
+    default: false
+    description: Save the result of the action as a json object in the st2 key store. Used when the expected result from Netbox is very large and the result will be piped to another action. You must also specify a save_in_key_store_keyname and an optional save_in_key_store_ttl.
+  save_in_key_store_key_name:
+    type: string
+    description: Name of the key to store the json result value in the st2 key store. Must be used with save_in_key_store and optionally save_in_key_store_ttl.
+  save_in_key_store_ttl:
+    type: integer
+    default: 60
+    description: TTL (seconds) of the saved json result in the st2 key store. Defaults to 60 seconds. Must be used with save_in_key_store and save_in_key_store_key_name.

--- a/actions/ipam_get_ip_addresses.yaml
+++ b/actions/ipam_get_ip_addresses.yaml
@@ -56,4 +56,14 @@ parameters:
     type: integer
     default: 0
     description: Offset result set by X objects. Used for pagination.
-
+  save_in_key_store:
+    type: boolean
+    default: false
+    description: Save the result of the action as a json object in the st2 key store. Used when the expected result from Netbox is very large and the result will be piped to another action. You must also specify a save_in_key_store_keyname and an optional save_in_key_store_ttl.
+  save_in_key_store_key_name:
+    type: string
+    description: Name of the key to store the json result value in the st2 key store. Must be used with save_in_key_store and optionally save_in_key_store_ttl.
+  save_in_key_store_ttl:
+    type: integer
+    default: 60
+    description: TTL (seconds) of the saved json result in the st2 key store. Defaults to 60 seconds. Must be used with save_in_key_store and save_in_key_store_key_name.

--- a/actions/ipam_get_prefixes.yaml
+++ b/actions/ipam_get_prefixes.yaml
@@ -65,3 +65,14 @@ parameters:
     type: integer
     default: 0
     description: Offset result set by X objects. Used for pagination.
+  save_in_key_store:
+    type: boolean
+    default: false
+    description: Save the result of the action as a json object in the st2 key store. Used when the expected result from Netbox is very large and the result will be piped to another action. You must also specify a save_in_key_store_keyname and an optional save_in_key_store_ttl.
+  save_in_key_store_key_name:
+    type: string
+    description: Name of the key to store the json result value in the st2 key store. Must be used with save_in_key_store and optionally save_in_key_store_ttl.
+  save_in_key_store_ttl:
+    type: integer
+    default: 60
+    description: TTL (seconds) of the saved json result in the st2 key store. Defaults to 60 seconds. Must be used with save_in_key_store and save_in_key_store_key_name.

--- a/actions/ipam_get_vlan_groups.yaml
+++ b/actions/ipam_get_vlan_groups.yaml
@@ -26,3 +26,14 @@ parameters:
     type: integer
     default: 0
     description: Offset result set by X objects. Used for pagination.
+  save_in_key_store:
+    type: boolean
+    default: false
+    description: Save the result of the action as a json object in the st2 key store. Used when the expected result from Netbox is very large and the result will be piped to another action. You must also specify a save_in_key_store_keyname and an optional save_in_key_store_ttl.
+  save_in_key_store_key_name:
+    type: string
+    description: Name of the key to store the json result value in the st2 key store. Must be used with save_in_key_store and optionally save_in_key_store_ttl.
+  save_in_key_store_ttl:
+    type: integer
+    default: 60
+    description: TTL (seconds) of the saved json result in the st2 key store. Defaults to 60 seconds. Must be used with save_in_key_store and save_in_key_store_key_name.

--- a/actions/ipam_get_vlans.yaml
+++ b/actions/ipam_get_vlans.yaml
@@ -56,3 +56,14 @@ parameters:
     type: integer
     default: 0
     description: Offset result set by X objects. Used for pagination.
+  save_in_key_store:
+    type: boolean
+    default: false
+    description: Save the result of the action as a json object in the st2 key store. Used when the expected result from Netbox is very large and the result will be piped to another action. You must also specify a save_in_key_store_keyname and an optional save_in_key_store_ttl.
+  save_in_key_store_key_name:
+    type: string
+    description: Name of the key to store the json result value in the st2 key store. Must be used with save_in_key_store and optionally save_in_key_store_ttl.
+  save_in_key_store_ttl:
+    type: integer
+    default: 60
+    description: TTL (seconds) of the saved json result in the st2 key store. Defaults to 60 seconds. Must be used with save_in_key_store and save_in_key_store_key_name.

--- a/actions/ipam_get_vrfs.yaml
+++ b/actions/ipam_get_vrfs.yaml
@@ -35,3 +35,14 @@ parameters:
     type: integer
     default: 0
     description: Offset result set by X objects. Used for pagination.
+  save_in_key_store:
+    type: boolean
+    default: false
+    description: Save the result of the action as a json object in the st2 key store. Used when the expected result from Netbox is very large and the result will be piped to another action. You must also specify a save_in_key_store_keyname and an optional save_in_key_store_ttl.
+  save_in_key_store_key_name:
+    type: string
+    description: Name of the key to store the json result value in the st2 key store. Must be used with save_in_key_store and optionally save_in_key_store_ttl.
+  save_in_key_store_ttl:
+    type: integer
+    default: 60
+    description: TTL (seconds) of the saved json result in the st2 key store. Defaults to 60 seconds. Must be used with save_in_key_store and save_in_key_store_key_name.

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
     - networking
     - ipam
     - dcim
-version: 0.2.1
+version: 0.3.0
 author: John Anderson, Jefferson White
 email: lampwins@gmail.com


### PR DESCRIPTION
Implements three new params on get actions which allow saving the result into the st2 key/value store. 

```
save_in_key_store:
  type: boolean
  default: false
  description: Save the result of the action as a json object in the st2 key store. Used when the expected result from Netbox is very large and the result will be piped to another action. You must also specify a save_in_key_store_keyname and an optional save_in_key_store_ttl.
save_in_key_store_key_name:
  type: string
  description: Name of the key to store the json result value in the st2 key store. Must be used with save_in_key_store and optionally save_in_key_store_ttl.
save_in_key_store_ttl:
  type: integer
  default: 60
  description: TTL (seconds) of the saved json result in the st2 key store. Defaults to 60 seconds. Must be used with save_in_key_store and save_in_key_store_key_name.
```