### PR TITLE
Fix DigitalOcean's name and hyperlink it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # stackstorm-netbox
 
-[NetBox](https://github.com/netbox-community/netbox) is an Open Source IPAM and DCIM tool
-maintained by [DigitalOcean](https://www.digitalocean.com/).
+[NetBox](https://github.com/netbox-community/netbox) is an Open Source IPAM and
+DCIM tool originally created by [DigitalOcean](https://www.digitalocean.com/).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # stackstorm-netbox
 
 [NetBox](https://github.com/digitalocean/netbox) is an Open Source IPAM and DCIM tool
-maintained by Digital Ocean.
+maintained by [DigitalOcean](https://www.digitalocean.com/).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stackstorm-netbox
 
-[NetBox](https://github.com/digitalocean/netbox) is an Open Source IPAM and DCIM tool
+[NetBox](https://github.com/netbox-community/netbox) is an Open Source IPAM and DCIM tool
 maintained by [DigitalOcean](https://www.digitalocean.com/).
 
 ## Configuration


### PR DESCRIPTION
The name "DigitalOcean" is a compound word (there's no space). Also, update the Netbox repository link and DigitalOcean's current role.