### PR TITLE
Add exceptions on action.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 3.0.6
+
+- Add exceptions on action.py
+
 ## 3.0.5
 
 - Bug fix: Tags fields need additional translation when modifying 

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -73,5 +73,9 @@ class NetboxBaseAction(Action):
             )
 
         if r:
-            return {"raw": r.json(), "status": r.status_code}
+            try:
+                raw = r.json()
+            except ValueError:
+                raw = r.text
+            return {"raw": raw, "status": r.status_code}
         return {"raw": {}, "status": 404}

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - networking
   - ipam
   - dcim
-version: 3.0.5
+version: 3.0.6
 author: John Anderson, Jefferson White
 email: lampwins@gmail.com
 python_versions:


### PR DESCRIPTION
On a Stackstorm workflow, the action netbox.delete.virtualization.virtual_machines works on NetBox but fails on Stackstorm.
When NetBox deletes an object, it replies a 204 error no content, r.json() fails.
The objective is that when NetBox replies a 500 error, the workflow works and it replies a string error in raw.