### PR TITLE
Enable use of encrypted secrets within the pack config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 3.4.3
+
+- Enable use of encrypted KVs in pack config schema
+
 ## 3.4.2
 
 - Updated spec as per v4.0
@@ -34,11 +38,11 @@
 
 ## 3.0.5
 
-- Bug fix: Tags fields need additional translation when modifying 
+- Bug fix: Tags fields need additional translation when modifying
 
 ## 3.0.4
 
-- Bug fix: PATCH requests don't need all the fields to be required 
+- Bug fix: PATCH requests don't need all the fields to be required
 
 ## 3.0.3
 

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -8,6 +8,7 @@ api_token:
   description: "API Token to use against the API"
   type: "string"
   required: true
+  secret: true
 
 use_https:
   description: "Use HTTPS when contacting the API"
@@ -33,3 +34,4 @@ sensor_secret:
   description: "When provided, will force request signature verification using the provided secret value."
   type: "string"
   default: ""
+  secret: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - networking
   - ipam
   - dcim
-version: 3.4.2
+version: 3.4.3
 python_versions:
   - "3"
 author: John Anderson, Jefferson White


### PR DESCRIPTION
Per https://github.com/StackStorm-Exchange/stackstorm-netbox/issues/52 this should enable the decryption/use of encrypted secrets in the KV (should the user wish to use that) in the pack config schema