### PR TITLE
Add optional custom ca_file_path setting to pack config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 3.4.4
+
+- Enable use of optional `ca_file_path` for custom CA certificates to allow ssl verification
+
 ## 3.4.3
 
 - Enable use of encrypted KVs in pack config schema

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -1,3 +1,4 @@
+import os
 import requests
 from st2common.runners.base_action import Action
 
@@ -17,6 +18,10 @@ class NetboxBaseAction(Action):
     def make_request(self, endpoint_uri, http_action, **kwargs):
         """Logic to make all types of requests
         """
+
+        # Handle custom CA certs built into the netbox pack via ca_file_path value
+        if self.config.get("ca_file_path"):
+            os.environ["REQUESTS_CA_BUNDLE"] = self.config["ca_file_path"]
 
         if self.config["use_https"]:
             url = "https://"

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -15,6 +15,11 @@ use_https:
   type: "boolean"
   required: true
 
+ca_file_path:
+  description: "Optional, specify a CA file path to use for SSL verification."
+  type: "string"
+  required: false
+
 ssl_verify:
   description: "Verify ssl/tls protocol certs when contacting the API."
   type: "boolean"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - networking
   - ipam
   - dcim
-version: 3.4.3
+version: 3.4.4
 python_versions:
   - "3"
 author: John Anderson, Jefferson White


### PR DESCRIPTION
Our use case / deployment of Netbox uses internal CA certificates that are not recognized/available in the current Netbox pack.

Adding a pack config to specify the custom `ca_file_path`, which then is set for netbox requests, would allow us to very easily change/use specific CA certificates AND `ssl_verify: true` without things exploding as the requests lib uses the default venv's cert file.