### PR TITLE
Feature/global default fail 2xxx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,22 @@ hostname: "netbox.corp.lan"
 api_token: "aaabbbccc111222333"
 use_https: true
 ssl_verify: true
+default_fail_non_2xx: false  # Optional: when true, actions fail on non-2xx NetBox responses by default
 ```
 
 After editing, run `sudo st2ctl reload --register-configs` to ensure your configuration
 is loaded.
+
+### Controlling action failure on non-2xx responses
+
+By default, NetBox actions in this pack **do not** fail when NetBox returns a non-2xx HTTP status unless the `fail_non_2xx` action parameter is explicitly set to `true`.
+
+- The pack configuration option `default_fail_non_2xx` controls the **default** behavior for all NetBox HTTP actions:
+  - If `default_fail_non_2xx` is `false` or omitted (the default), actions will only fail on non-2xx responses when `fail_non_2xx=true` is explicitly set on the action invocation.
+  - If `default_fail_non_2xx` is `true`, actions will fail on non-2xx responses **by default**, unless explicitly overridden.
+- The per-action parameter `fail_non_2xx` always takes precedence over the pack config:
+  - `fail_non_2xx=true` forces the action to fail on non-2xx responses, regardless of `default_fail_non_2xx`.
+  - `fail_non_2xx=false` forces the action **not** to fail on non-2xx responses, even if `default_fail_non_2xx` is `true`.
 
 ## Actions
 

--- a/actions/delete.circuits.circuit_group_assignments.yaml
+++ b/actions/delete.circuits.circuit_group_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.circuits.circuit_groups.yaml
+++ b/actions/delete.circuits.circuit_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.circuits.circuit_terminations.yaml
+++ b/actions/delete.circuits.circuit_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.circuits.circuit_types.yaml
+++ b/actions/delete.circuits.circuit_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.circuits.circuits.yaml
+++ b/actions/delete.circuits.circuits.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.circuits.provider_accounts.yaml
+++ b/actions/delete.circuits.provider_accounts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.circuits.provider_networks.yaml
+++ b/actions/delete.circuits.provider_networks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.circuits.providers.yaml
+++ b/actions/delete.circuits.providers.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.circuits.virtual_circuit_terminations.yaml
+++ b/actions/delete.circuits.virtual_circuit_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.circuits.virtual_circuit_types.yaml
+++ b/actions/delete.circuits.virtual_circuit_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.circuits.virtual_circuits.yaml
+++ b/actions/delete.circuits.virtual_circuits.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.core.data_sources.yaml
+++ b/actions/delete.core.data_sources.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.cable_terminations.yaml
+++ b/actions/delete.dcim.cable_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.cables.yaml
+++ b/actions/delete.dcim.cables.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.console_port_templates.yaml
+++ b/actions/delete.dcim.console_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.console_ports.yaml
+++ b/actions/delete.dcim.console_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.console_server_port_templates.yaml
+++ b/actions/delete.dcim.console_server_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.console_server_ports.yaml
+++ b/actions/delete.dcim.console_server_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.device_bay_templates.yaml
+++ b/actions/delete.dcim.device_bay_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.device_bays.yaml
+++ b/actions/delete.dcim.device_bays.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.device_roles.yaml
+++ b/actions/delete.dcim.device_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.device_types.yaml
+++ b/actions/delete.dcim.device_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.devices.yaml
+++ b/actions/delete.dcim.devices.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.front_port_templates.yaml
+++ b/actions/delete.dcim.front_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.front_ports.yaml
+++ b/actions/delete.dcim.front_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.interface_templates.yaml
+++ b/actions/delete.dcim.interface_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.interfaces.yaml
+++ b/actions/delete.dcim.interfaces.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.inventory_item_roles.yaml
+++ b/actions/delete.dcim.inventory_item_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.inventory_item_templates.yaml
+++ b/actions/delete.dcim.inventory_item_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.inventory_items.yaml
+++ b/actions/delete.dcim.inventory_items.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.locations.yaml
+++ b/actions/delete.dcim.locations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.mac_addresses.yaml
+++ b/actions/delete.dcim.mac_addresses.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.manufacturers.yaml
+++ b/actions/delete.dcim.manufacturers.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.module_bay_templates.yaml
+++ b/actions/delete.dcim.module_bay_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.module_bays.yaml
+++ b/actions/delete.dcim.module_bays.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.module_type_profiles.yaml
+++ b/actions/delete.dcim.module_type_profiles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.module_types.yaml
+++ b/actions/delete.dcim.module_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.modules.yaml
+++ b/actions/delete.dcim.modules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.platforms.yaml
+++ b/actions/delete.dcim.platforms.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.power_feeds.yaml
+++ b/actions/delete.dcim.power_feeds.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.power_outlet_templates.yaml
+++ b/actions/delete.dcim.power_outlet_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.power_outlets.yaml
+++ b/actions/delete.dcim.power_outlets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.power_panels.yaml
+++ b/actions/delete.dcim.power_panels.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.power_port_templates.yaml
+++ b/actions/delete.dcim.power_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.power_ports.yaml
+++ b/actions/delete.dcim.power_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.rack_reservations.yaml
+++ b/actions/delete.dcim.rack_reservations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.rack_roles.yaml
+++ b/actions/delete.dcim.rack_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.rack_types.yaml
+++ b/actions/delete.dcim.rack_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.racks.yaml
+++ b/actions/delete.dcim.racks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.rear_port_templates.yaml
+++ b/actions/delete.dcim.rear_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.rear_ports.yaml
+++ b/actions/delete.dcim.rear_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.regions.yaml
+++ b/actions/delete.dcim.regions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.site_groups.yaml
+++ b/actions/delete.dcim.site_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.sites.yaml
+++ b/actions/delete.dcim.sites.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.virtual_chassis.yaml
+++ b/actions/delete.dcim.virtual_chassis.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.dcim.virtual_device_contexts.yaml
+++ b/actions/delete.dcim.virtual_device_contexts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.bookmarks.yaml
+++ b/actions/delete.extras.bookmarks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.config_contexts.yaml
+++ b/actions/delete.extras.config_contexts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.config_templates.yaml
+++ b/actions/delete.extras.config_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.custom_field_choice_sets.yaml
+++ b/actions/delete.extras.custom_field_choice_sets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.custom_fields.yaml
+++ b/actions/delete.extras.custom_fields.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.custom_links.yaml
+++ b/actions/delete.extras.custom_links.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.dashboard.yaml
+++ b/actions/delete.extras.dashboard.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.event_rules.yaml
+++ b/actions/delete.extras.event_rules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.export_templates.yaml
+++ b/actions/delete.extras.export_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.image_attachments.yaml
+++ b/actions/delete.extras.image_attachments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.journal_entries.yaml
+++ b/actions/delete.extras.journal_entries.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.notification_groups.yaml
+++ b/actions/delete.extras.notification_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.notifications.yaml
+++ b/actions/delete.extras.notifications.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.saved_filters.yaml
+++ b/actions/delete.extras.saved_filters.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.scripts.yaml
+++ b/actions/delete.extras.scripts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.subscriptions.yaml
+++ b/actions/delete.extras.subscriptions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.table_configs.yaml
+++ b/actions/delete.extras.table_configs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.tags.yaml
+++ b/actions/delete.extras.tags.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.extras.webhooks.yaml
+++ b/actions/delete.extras.webhooks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.aggregates.yaml
+++ b/actions/delete.ipam.aggregates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.asn_ranges.yaml
+++ b/actions/delete.ipam.asn_ranges.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.asns.yaml
+++ b/actions/delete.ipam.asns.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.fhrp_group_assignments.yaml
+++ b/actions/delete.ipam.fhrp_group_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.fhrp_groups.yaml
+++ b/actions/delete.ipam.fhrp_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.ip_addresses.yaml
+++ b/actions/delete.ipam.ip_addresses.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.ip_ranges.yaml
+++ b/actions/delete.ipam.ip_ranges.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.prefixes.yaml
+++ b/actions/delete.ipam.prefixes.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.rirs.yaml
+++ b/actions/delete.ipam.rirs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.roles.yaml
+++ b/actions/delete.ipam.roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.route_targets.yaml
+++ b/actions/delete.ipam.route_targets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.service_templates.yaml
+++ b/actions/delete.ipam.service_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.services.yaml
+++ b/actions/delete.ipam.services.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.vlan_groups.yaml
+++ b/actions/delete.ipam.vlan_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.vlan_translation_policies.yaml
+++ b/actions/delete.ipam.vlan_translation_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.vlan_translation_rules.yaml
+++ b/actions/delete.ipam.vlan_translation_rules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.vlans.yaml
+++ b/actions/delete.ipam.vlans.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.ipam.vrfs.yaml
+++ b/actions/delete.ipam.vrfs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.tenancy.contact_assignments.yaml
+++ b/actions/delete.tenancy.contact_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.tenancy.contact_groups.yaml
+++ b/actions/delete.tenancy.contact_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.tenancy.contact_roles.yaml
+++ b/actions/delete.tenancy.contact_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.tenancy.contacts.yaml
+++ b/actions/delete.tenancy.contacts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.tenancy.tenant_groups.yaml
+++ b/actions/delete.tenancy.tenant_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.tenancy.tenants.yaml
+++ b/actions/delete.tenancy.tenants.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.users.groups.yaml
+++ b/actions/delete.users.groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.users.permissions.yaml
+++ b/actions/delete.users.permissions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.users.tokens.yaml
+++ b/actions/delete.users.tokens.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.users.users.yaml
+++ b/actions/delete.users.users.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.virtualization.cluster_groups.yaml
+++ b/actions/delete.virtualization.cluster_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.virtualization.cluster_types.yaml
+++ b/actions/delete.virtualization.cluster_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.virtualization.clusters.yaml
+++ b/actions/delete.virtualization.clusters.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.virtualization.interfaces.yaml
+++ b/actions/delete.virtualization.interfaces.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.virtualization.virtual_disks.yaml
+++ b/actions/delete.virtualization.virtual_disks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.virtualization.virtual_machines.yaml
+++ b/actions/delete.virtualization.virtual_machines.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.vpn.ike_policies.yaml
+++ b/actions/delete.vpn.ike_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.vpn.ike_proposals.yaml
+++ b/actions/delete.vpn.ike_proposals.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.vpn.ipsec_policies.yaml
+++ b/actions/delete.vpn.ipsec_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.vpn.ipsec_profiles.yaml
+++ b/actions/delete.vpn.ipsec_profiles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.vpn.ipsec_proposals.yaml
+++ b/actions/delete.vpn.ipsec_proposals.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.vpn.l2vpn_terminations.yaml
+++ b/actions/delete.vpn.l2vpn_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.vpn.l2vpns.yaml
+++ b/actions/delete.vpn.l2vpns.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.vpn.tunnel_groups.yaml
+++ b/actions/delete.vpn.tunnel_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.vpn.tunnel_terminations.yaml
+++ b/actions/delete.vpn.tunnel_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.vpn.tunnels.yaml
+++ b/actions/delete.vpn.tunnels.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.wireless.wireless_lan_groups.yaml
+++ b/actions/delete.wireless.wireless_lan_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.wireless.wireless_lans.yaml
+++ b/actions/delete.wireless.wireless_lans.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/delete.wireless.wireless_links.yaml
+++ b/actions/delete.wireless.wireless_links.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.circuits.circuit_group_assignments.yaml
+++ b/actions/get.circuits.circuit_group_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   circuit:

--- a/actions/get.circuits.circuit_groups.yaml
+++ b/actions/get.circuits.circuit_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.circuits.circuit_terminations.paths.yaml
+++ b/actions/get.circuits.circuit_terminations.paths.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.circuits.circuit_terminations.yaml
+++ b/actions/get.circuits.circuit_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cable_end:

--- a/actions/get.circuits.circuit_types.yaml
+++ b/actions/get.circuits.circuit_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   color:

--- a/actions/get.circuits.circuits.yaml
+++ b/actions/get.circuits.circuits.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cid:

--- a/actions/get.circuits.provider_accounts.yaml
+++ b/actions/get.circuits.provider_accounts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   account:

--- a/actions/get.circuits.provider_networks.yaml
+++ b/actions/get.circuits.provider_networks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.circuits.providers.yaml
+++ b/actions/get.circuits.providers.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   asn:

--- a/actions/get.circuits.virtual_circuit_terminations.paths.yaml
+++ b/actions/get.circuits.virtual_circuit_terminations.paths.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.circuits.virtual_circuit_terminations.yaml
+++ b/actions/get.circuits.virtual_circuit_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.circuits.virtual_circuit_types.yaml
+++ b/actions/get.circuits.virtual_circuit_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   color:

--- a/actions/get.circuits.virtual_circuits.yaml
+++ b/actions/get.circuits.virtual_circuits.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cid:

--- a/actions/get.core.data_files.yaml
+++ b/actions/get.core.data_files.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.core.data_sources.yaml
+++ b/actions/get.core.data_sources.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.core.jobs.yaml
+++ b/actions/get.core.jobs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   completed:

--- a/actions/get.core.object_changes.yaml
+++ b/actions/get.core.object_changes.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   action:

--- a/actions/get.dcim.cable_terminations.yaml
+++ b/actions/get.dcim.cable_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cable:

--- a/actions/get.dcim.cables.yaml
+++ b/actions/get.dcim.cables.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   circuittermination_id:

--- a/actions/get.dcim.connected_device.yaml
+++ b/actions/get.dcim.connected_device.yaml
@@ -23,7 +23,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   peer_device:

--- a/actions/get.dcim.console_port_templates.yaml
+++ b/actions/get.dcim.console_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.dcim.console_ports.trace.yaml
+++ b/actions/get.dcim.console_ports.trace.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.dcim.console_ports.yaml
+++ b/actions/get.dcim.console_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cable_end:

--- a/actions/get.dcim.console_server_port_templates.yaml
+++ b/actions/get.dcim.console_server_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.dcim.console_server_ports.trace.yaml
+++ b/actions/get.dcim.console_server_ports.trace.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.dcim.console_server_ports.yaml
+++ b/actions/get.dcim.console_server_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cable_end:

--- a/actions/get.dcim.device_bay_templates.yaml
+++ b/actions/get.dcim.device_bay_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.dcim.device_bays.yaml
+++ b/actions/get.dcim.device_bays.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.dcim.device_roles.yaml
+++ b/actions/get.dcim.device_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   ancestor:

--- a/actions/get.dcim.device_types.yaml
+++ b/actions/get.dcim.device_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   airflow:

--- a/actions/get.dcim.devices.yaml
+++ b/actions/get.dcim.devices.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   airflow:

--- a/actions/get.dcim.front_port_templates.yaml
+++ b/actions/get.dcim.front_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   color:

--- a/actions/get.dcim.front_ports.paths.yaml
+++ b/actions/get.dcim.front_ports.paths.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.dcim.front_ports.yaml
+++ b/actions/get.dcim.front_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cable_end:

--- a/actions/get.dcim.interface_templates.yaml
+++ b/actions/get.dcim.interface_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   bridge_id:

--- a/actions/get.dcim.interfaces.trace.yaml
+++ b/actions/get.dcim.interfaces.trace.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.dcim.interfaces.yaml
+++ b/actions/get.dcim.interfaces.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   bridge_id:

--- a/actions/get.dcim.inventory_item_roles.yaml
+++ b/actions/get.dcim.inventory_item_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   color:

--- a/actions/get.dcim.inventory_item_templates.yaml
+++ b/actions/get.dcim.inventory_item_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   component_id:

--- a/actions/get.dcim.inventory_items.yaml
+++ b/actions/get.dcim.inventory_items.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   asset_tag:

--- a/actions/get.dcim.locations.yaml
+++ b/actions/get.dcim.locations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   ancestor:

--- a/actions/get.dcim.mac_addresses.yaml
+++ b/actions/get.dcim.mac_addresses.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   assigned_object_id:

--- a/actions/get.dcim.manufacturers.yaml
+++ b/actions/get.dcim.manufacturers.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   contact:

--- a/actions/get.dcim.module_bay_templates.yaml
+++ b/actions/get.dcim.module_bay_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.dcim.module_bays.yaml
+++ b/actions/get.dcim.module_bays.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.dcim.module_type_profiles.yaml
+++ b/actions/get.dcim.module_type_profiles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.dcim.module_types.yaml
+++ b/actions/get.dcim.module_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   airflow:

--- a/actions/get.dcim.modules.yaml
+++ b/actions/get.dcim.modules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   asset_tag:

--- a/actions/get.dcim.platforms.yaml
+++ b/actions/get.dcim.platforms.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   available_for_device_type:

--- a/actions/get.dcim.power_feeds.trace.yaml
+++ b/actions/get.dcim.power_feeds.trace.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.dcim.power_feeds.yaml
+++ b/actions/get.dcim.power_feeds.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   amperage:

--- a/actions/get.dcim.power_outlet_templates.yaml
+++ b/actions/get.dcim.power_outlet_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.dcim.power_outlets.trace.yaml
+++ b/actions/get.dcim.power_outlets.trace.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.dcim.power_outlets.yaml
+++ b/actions/get.dcim.power_outlets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cable_end:

--- a/actions/get.dcim.power_panels.yaml
+++ b/actions/get.dcim.power_panels.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   contact:

--- a/actions/get.dcim.power_port_templates.yaml
+++ b/actions/get.dcim.power_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   allocated_draw:

--- a/actions/get.dcim.power_ports.trace.yaml
+++ b/actions/get.dcim.power_ports.trace.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.dcim.power_ports.yaml
+++ b/actions/get.dcim.power_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   allocated_draw:

--- a/actions/get.dcim.rack_reservations.yaml
+++ b/actions/get.dcim.rack_reservations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.dcim.rack_roles.yaml
+++ b/actions/get.dcim.rack_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   color:

--- a/actions/get.dcim.rack_types.yaml
+++ b/actions/get.dcim.rack_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.dcim.racks.elevation.yaml
+++ b/actions/get.dcim.racks.elevation.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.dcim.racks.yaml
+++ b/actions/get.dcim.racks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   airflow:

--- a/actions/get.dcim.rear_port_templates.yaml
+++ b/actions/get.dcim.rear_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   color:

--- a/actions/get.dcim.rear_ports.paths.yaml
+++ b/actions/get.dcim.rear_ports.paths.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.dcim.rear_ports.yaml
+++ b/actions/get.dcim.rear_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cable_end:

--- a/actions/get.dcim.regions.yaml
+++ b/actions/get.dcim.regions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   ancestor:

--- a/actions/get.dcim.site_groups.yaml
+++ b/actions/get.dcim.site_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   ancestor:

--- a/actions/get.dcim.sites.yaml
+++ b/actions/get.dcim.sites.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   asn:

--- a/actions/get.dcim.virtual_chassis.yaml
+++ b/actions/get.dcim.virtual_chassis.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.dcim.virtual_device_contexts.yaml
+++ b/actions/get.dcim.virtual_device_contexts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.extras.bookmarks.yaml
+++ b/actions/get.extras.bookmarks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.extras.config_contexts.yaml
+++ b/actions/get.extras.config_contexts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   auto_sync_enabled:

--- a/actions/get.extras.config_templates.yaml
+++ b/actions/get.extras.config_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   as_attachment:

--- a/actions/get.extras.custom_field_choice_sets.choices.yaml
+++ b/actions/get.extras.custom_field_choice_sets.choices.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.extras.custom_field_choice_sets.yaml
+++ b/actions/get.extras.custom_field_choice_sets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   base_choices:

--- a/actions/get.extras.custom_fields.yaml
+++ b/actions/get.extras.custom_fields.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   choice_set:

--- a/actions/get.extras.custom_links.yaml
+++ b/actions/get.extras.custom_links.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   button_class:

--- a/actions/get.extras.event_rules.yaml
+++ b/actions/get.extras.event_rules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   action_object_id:

--- a/actions/get.extras.export_templates.yaml
+++ b/actions/get.extras.export_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   as_attachment:

--- a/actions/get.extras.image_attachments.yaml
+++ b/actions/get.extras.image_attachments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.extras.journal_entries.yaml
+++ b/actions/get.extras.journal_entries.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   assigned_object_id:

--- a/actions/get.extras.notification_groups.yaml
+++ b/actions/get.extras.notification_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   limit:

--- a/actions/get.extras.notifications.yaml
+++ b/actions/get.extras.notifications.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   limit:

--- a/actions/get.extras.object_types.yaml
+++ b/actions/get.extras.object_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   app_label:

--- a/actions/get.extras.saved_filters.yaml
+++ b/actions/get.extras.saved_filters.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.extras.scripts.yaml
+++ b/actions/get.extras.scripts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.extras.subscriptions.yaml
+++ b/actions/get.extras.subscriptions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   limit:

--- a/actions/get.extras.table_configs.yaml
+++ b/actions/get.extras.table_configs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.extras.tagged_objects.yaml
+++ b/actions/get.extras.tagged_objects.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.extras.tags.yaml
+++ b/actions/get.extras.tags.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   color:

--- a/actions/get.extras.webhooks.yaml
+++ b/actions/get.extras.webhooks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   ca_file_path:

--- a/actions/get.ipam.aggregates.yaml
+++ b/actions/get.ipam.aggregates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   contact:

--- a/actions/get.ipam.asn_ranges.available_asns.yaml
+++ b/actions/get.ipam.asn_ranges.available_asns.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.ipam.asn_ranges.yaml
+++ b/actions/get.ipam.asn_ranges.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.ipam.asns.yaml
+++ b/actions/get.ipam.asns.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   asn:

--- a/actions/get.ipam.fhrp_group_assignments.yaml
+++ b/actions/get.ipam.fhrp_group_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.ipam.fhrp_groups.yaml
+++ b/actions/get.ipam.fhrp_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   auth_key:

--- a/actions/get.ipam.ip_addresses.yaml
+++ b/actions/get.ipam.ip_addresses.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   address:

--- a/actions/get.ipam.ip_ranges.available_ips.yaml
+++ b/actions/get.ipam.ip_ranges.available_ips.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.ipam.ip_ranges.yaml
+++ b/actions/get.ipam.ip_ranges.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   contact:

--- a/actions/get.ipam.prefixes.available_ips.yaml
+++ b/actions/get.ipam.prefixes.available_ips.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.ipam.prefixes.available_prefixes.yaml
+++ b/actions/get.ipam.prefixes.available_prefixes.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.ipam.prefixes.yaml
+++ b/actions/get.ipam.prefixes.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   children:

--- a/actions/get.ipam.rirs.yaml
+++ b/actions/get.ipam.rirs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.ipam.roles.yaml
+++ b/actions/get.ipam.roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.ipam.route_targets.yaml
+++ b/actions/get.ipam.route_targets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.ipam.service_templates.yaml
+++ b/actions/get.ipam.service_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.ipam.services.yaml
+++ b/actions/get.ipam.services.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   contact:

--- a/actions/get.ipam.vlan_groups.available_vlans.yaml
+++ b/actions/get.ipam.vlan_groups.available_vlans.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   id:

--- a/actions/get.ipam.vlan_groups.yaml
+++ b/actions/get.ipam.vlan_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cluster:

--- a/actions/get.ipam.vlan_translation_policies.yaml
+++ b/actions/get.ipam.vlan_translation_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.ipam.vlan_translation_rules.yaml
+++ b/actions/get.ipam.vlan_translation_rules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.ipam.vlans.yaml
+++ b/actions/get.ipam.vlans.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   available_at_site:

--- a/actions/get.ipam.vrfs.yaml
+++ b/actions/get.ipam.vrfs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.tenancy.contact_assignments.yaml
+++ b/actions/get.tenancy.contact_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   contact_id:

--- a/actions/get.tenancy.contact_groups.yaml
+++ b/actions/get.tenancy.contact_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   ancestor:

--- a/actions/get.tenancy.contact_roles.yaml
+++ b/actions/get.tenancy.contact_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.tenancy.contacts.yaml
+++ b/actions/get.tenancy.contacts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   address:

--- a/actions/get.tenancy.tenant_groups.yaml
+++ b/actions/get.tenancy.tenant_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   ancestor:

--- a/actions/get.tenancy.tenants.yaml
+++ b/actions/get.tenancy.tenants.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   contact:

--- a/actions/get.users.groups.yaml
+++ b/actions/get.users.groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   description:

--- a/actions/get.users.permissions.yaml
+++ b/actions/get.users.permissions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   can_add:

--- a/actions/get.users.tokens.yaml
+++ b/actions/get.users.tokens.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.users.users.yaml
+++ b/actions/get.users.users.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   date_joined:

--- a/actions/get.virtualization.cluster_groups.yaml
+++ b/actions/get.virtualization.cluster_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   contact:

--- a/actions/get.virtualization.cluster_types.yaml
+++ b/actions/get.virtualization.cluster_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.virtualization.clusters.yaml
+++ b/actions/get.virtualization.clusters.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   contact:

--- a/actions/get.virtualization.interfaces.yaml
+++ b/actions/get.virtualization.interfaces.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   bridge_id:

--- a/actions/get.virtualization.virtual_disks.yaml
+++ b/actions/get.virtualization.virtual_disks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.virtualization.virtual_machines.yaml
+++ b/actions/get.virtualization.virtual_machines.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cluster:

--- a/actions/get.vpn.ike_policies.yaml
+++ b/actions/get.vpn.ike_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.vpn.ike_proposals.yaml
+++ b/actions/get.vpn.ike_proposals.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   authentication_algorithm:

--- a/actions/get.vpn.ipsec_policies.yaml
+++ b/actions/get.vpn.ipsec_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.vpn.ipsec_profiles.yaml
+++ b/actions/get.vpn.ipsec_profiles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.vpn.ipsec_proposals.yaml
+++ b/actions/get.vpn.ipsec_proposals.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   authentication_algorithm:

--- a/actions/get.vpn.l2vpn_terminations.yaml
+++ b/actions/get.vpn.l2vpn_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   assigned_object_id:

--- a/actions/get.vpn.l2vpns.yaml
+++ b/actions/get.vpn.l2vpns.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   contact:

--- a/actions/get.vpn.tunnel_groups.yaml
+++ b/actions/get.vpn.tunnel_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   contact:

--- a/actions/get.vpn.tunnel_terminations.yaml
+++ b/actions/get.vpn.tunnel_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   created:

--- a/actions/get.vpn.tunnels.yaml
+++ b/actions/get.vpn.tunnels.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   contact:

--- a/actions/get.wireless.wireless_lan_groups.yaml
+++ b/actions/get.wireless.wireless_lan_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   ancestor:

--- a/actions/get.wireless.wireless_lans.yaml
+++ b/actions/get.wireless.wireless_lans.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   auth_cipher:

--- a/actions/get.wireless.wireless_links.yaml
+++ b/actions/get.wireless.wireless_links.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   auth_cipher:

--- a/actions/patch.circuits.circuit_group_assignments.yaml
+++ b/actions/patch.circuits.circuit_group_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   group:

--- a/actions/patch.circuits.circuit_groups.yaml
+++ b/actions/patch.circuits.circuit_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.circuits.circuit_terminations.yaml
+++ b/actions/patch.circuits.circuit_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   circuit:

--- a/actions/patch.circuits.circuit_types.yaml
+++ b/actions/patch.circuits.circuit_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.circuits.circuits.yaml
+++ b/actions/patch.circuits.circuits.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cid:

--- a/actions/patch.circuits.provider_accounts.yaml
+++ b/actions/patch.circuits.provider_accounts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   provider:

--- a/actions/patch.circuits.provider_networks.yaml
+++ b/actions/patch.circuits.provider_networks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   provider:

--- a/actions/patch.circuits.providers.yaml
+++ b/actions/patch.circuits.providers.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.circuits.virtual_circuit_terminations.yaml
+++ b/actions/patch.circuits.virtual_circuit_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   virtual_circuit:

--- a/actions/patch.circuits.virtual_circuit_types.yaml
+++ b/actions/patch.circuits.virtual_circuit_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.circuits.virtual_circuits.yaml
+++ b/actions/patch.circuits.virtual_circuits.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cid:

--- a/actions/patch.core.data_sources.yaml
+++ b/actions/patch.core.data_sources.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.cable_terminations.yaml
+++ b/actions/patch.dcim.cable_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cable:

--- a/actions/patch.dcim.cables.yaml
+++ b/actions/patch.dcim.cables.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   type:

--- a/actions/patch.dcim.console_port_templates.yaml
+++ b/actions/patch.dcim.console_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/patch.dcim.console_ports.yaml
+++ b/actions/patch.dcim.console_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/patch.dcim.console_server_port_templates.yaml
+++ b/actions/patch.dcim.console_server_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/patch.dcim.console_server_ports.yaml
+++ b/actions/patch.dcim.console_server_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/patch.dcim.device_bay_templates.yaml
+++ b/actions/patch.dcim.device_bay_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/patch.dcim.device_bays.yaml
+++ b/actions/patch.dcim.device_bays.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/patch.dcim.device_roles.yaml
+++ b/actions/patch.dcim.device_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.device_types.yaml
+++ b/actions/patch.dcim.device_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   manufacturer:

--- a/actions/patch.dcim.devices.yaml
+++ b/actions/patch.dcim.devices.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.front_port_templates.yaml
+++ b/actions/patch.dcim.front_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/patch.dcim.front_ports.yaml
+++ b/actions/patch.dcim.front_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/patch.dcim.interface_templates.yaml
+++ b/actions/patch.dcim.interface_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/patch.dcim.interfaces.yaml
+++ b/actions/patch.dcim.interfaces.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/patch.dcim.inventory_item_roles.yaml
+++ b/actions/patch.dcim.inventory_item_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.inventory_item_templates.yaml
+++ b/actions/patch.dcim.inventory_item_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/patch.dcim.inventory_items.yaml
+++ b/actions/patch.dcim.inventory_items.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/patch.dcim.locations.yaml
+++ b/actions/patch.dcim.locations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.mac_addresses.yaml
+++ b/actions/patch.dcim.mac_addresses.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   mac_address:

--- a/actions/patch.dcim.manufacturers.yaml
+++ b/actions/patch.dcim.manufacturers.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.module_bay_templates.yaml
+++ b/actions/patch.dcim.module_bay_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/patch.dcim.module_bays.yaml
+++ b/actions/patch.dcim.module_bays.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/patch.dcim.module_type_profiles.yaml
+++ b/actions/patch.dcim.module_type_profiles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.module_types.yaml
+++ b/actions/patch.dcim.module_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   profile:

--- a/actions/patch.dcim.modules.yaml
+++ b/actions/patch.dcim.modules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/patch.dcim.platforms.yaml
+++ b/actions/patch.dcim.platforms.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.power_feeds.yaml
+++ b/actions/patch.dcim.power_feeds.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   power_panel:

--- a/actions/patch.dcim.power_outlet_templates.yaml
+++ b/actions/patch.dcim.power_outlet_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/patch.dcim.power_outlets.yaml
+++ b/actions/patch.dcim.power_outlets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/patch.dcim.power_panels.yaml
+++ b/actions/patch.dcim.power_panels.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   site:

--- a/actions/patch.dcim.power_port_templates.yaml
+++ b/actions/patch.dcim.power_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/patch.dcim.power_ports.yaml
+++ b/actions/patch.dcim.power_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/patch.dcim.rack_reservations.yaml
+++ b/actions/patch.dcim.rack_reservations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   rack:

--- a/actions/patch.dcim.rack_roles.yaml
+++ b/actions/patch.dcim.rack_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.rack_types.yaml
+++ b/actions/patch.dcim.rack_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   manufacturer:

--- a/actions/patch.dcim.racks.yaml
+++ b/actions/patch.dcim.racks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.rear_port_templates.yaml
+++ b/actions/patch.dcim.rear_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/patch.dcim.rear_ports.yaml
+++ b/actions/patch.dcim.rear_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/patch.dcim.regions.yaml
+++ b/actions/patch.dcim.regions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.site_groups.yaml
+++ b/actions/patch.dcim.site_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.sites.yaml
+++ b/actions/patch.dcim.sites.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.virtual_chassis.yaml
+++ b/actions/patch.dcim.virtual_chassis.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.dcim.virtual_device_contexts.yaml
+++ b/actions/patch.dcim.virtual_device_contexts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.extras.bookmarks.yaml
+++ b/actions/patch.extras.bookmarks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/patch.extras.config_contexts.yaml
+++ b/actions/patch.extras.config_contexts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.extras.config_templates.yaml
+++ b/actions/patch.extras.config_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.extras.custom_field_choice_sets.yaml
+++ b/actions/patch.extras.custom_field_choice_sets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.extras.custom_fields.yaml
+++ b/actions/patch.extras.custom_fields.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/patch.extras.custom_links.yaml
+++ b/actions/patch.extras.custom_links.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/patch.extras.dashboard.yaml
+++ b/actions/patch.extras.dashboard.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   layout:

--- a/actions/patch.extras.event_rules.yaml
+++ b/actions/patch.extras.event_rules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/patch.extras.export_templates.yaml
+++ b/actions/patch.extras.export_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/patch.extras.image_attachments.yaml
+++ b/actions/patch.extras.image_attachments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/patch.extras.journal_entries.yaml
+++ b/actions/patch.extras.journal_entries.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   assigned_object_type:

--- a/actions/patch.extras.notification_groups.yaml
+++ b/actions/patch.extras.notification_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.extras.notifications.yaml
+++ b/actions/patch.extras.notifications.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/patch.extras.saved_filters.yaml
+++ b/actions/patch.extras.saved_filters.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/patch.extras.scripts.yaml
+++ b/actions/patch.extras.scripts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   data:

--- a/actions/patch.extras.subscriptions.yaml
+++ b/actions/patch.extras.subscriptions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/patch.extras.table_configs.yaml
+++ b/actions/patch.extras.table_configs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/patch.extras.tags.yaml
+++ b/actions/patch.extras.tags.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.extras.webhooks.yaml
+++ b/actions/patch.extras.webhooks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.ipam.aggregates.yaml
+++ b/actions/patch.ipam.aggregates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   prefix:

--- a/actions/patch.ipam.asn_ranges.yaml
+++ b/actions/patch.ipam.asn_ranges.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.ipam.asns.yaml
+++ b/actions/patch.ipam.asns.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   asn:

--- a/actions/patch.ipam.fhrp_group_assignments.yaml
+++ b/actions/patch.ipam.fhrp_group_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   group:

--- a/actions/patch.ipam.fhrp_groups.yaml
+++ b/actions/patch.ipam.fhrp_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.ipam.ip_addresses.yaml
+++ b/actions/patch.ipam.ip_addresses.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   address:

--- a/actions/patch.ipam.ip_ranges.yaml
+++ b/actions/patch.ipam.ip_ranges.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   start_address:

--- a/actions/patch.ipam.prefixes.yaml
+++ b/actions/patch.ipam.prefixes.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   prefix:

--- a/actions/patch.ipam.rirs.yaml
+++ b/actions/patch.ipam.rirs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.ipam.roles.yaml
+++ b/actions/patch.ipam.roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.ipam.route_targets.yaml
+++ b/actions/patch.ipam.route_targets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.ipam.service_templates.yaml
+++ b/actions/patch.ipam.service_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.ipam.services.yaml
+++ b/actions/patch.ipam.services.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   parent_object_type:

--- a/actions/patch.ipam.vlan_groups.yaml
+++ b/actions/patch.ipam.vlan_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.ipam.vlan_translation_policies.yaml
+++ b/actions/patch.ipam.vlan_translation_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.ipam.vlan_translation_rules.yaml
+++ b/actions/patch.ipam.vlan_translation_rules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   policy:

--- a/actions/patch.ipam.vlans.yaml
+++ b/actions/patch.ipam.vlans.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   site:

--- a/actions/patch.ipam.vrfs.yaml
+++ b/actions/patch.ipam.vrfs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.tenancy.contact_assignments.yaml
+++ b/actions/patch.tenancy.contact_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/patch.tenancy.contact_groups.yaml
+++ b/actions/patch.tenancy.contact_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.tenancy.contact_roles.yaml
+++ b/actions/patch.tenancy.contact_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.tenancy.contacts.yaml
+++ b/actions/patch.tenancy.contacts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   groups:

--- a/actions/patch.tenancy.tenant_groups.yaml
+++ b/actions/patch.tenancy.tenant_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.tenancy.tenants.yaml
+++ b/actions/patch.tenancy.tenants.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.users.groups.yaml
+++ b/actions/patch.users.groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.users.permissions.yaml
+++ b/actions/patch.users.permissions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.users.tokens.yaml
+++ b/actions/patch.users.tokens.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   user:

--- a/actions/patch.users.users.yaml
+++ b/actions/patch.users.users.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   username:

--- a/actions/patch.virtualization.cluster_groups.yaml
+++ b/actions/patch.virtualization.cluster_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.virtualization.cluster_types.yaml
+++ b/actions/patch.virtualization.cluster_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.virtualization.clusters.yaml
+++ b/actions/patch.virtualization.clusters.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.virtualization.interfaces.yaml
+++ b/actions/patch.virtualization.interfaces.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   virtual_machine:

--- a/actions/patch.virtualization.virtual_disks.yaml
+++ b/actions/patch.virtualization.virtual_disks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   virtual_machine:

--- a/actions/patch.virtualization.virtual_machines.yaml
+++ b/actions/patch.virtualization.virtual_machines.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.vpn.ike_policies.yaml
+++ b/actions/patch.vpn.ike_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.vpn.ike_proposals.yaml
+++ b/actions/patch.vpn.ike_proposals.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.vpn.ipsec_policies.yaml
+++ b/actions/patch.vpn.ipsec_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.vpn.ipsec_profiles.yaml
+++ b/actions/patch.vpn.ipsec_profiles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.vpn.ipsec_proposals.yaml
+++ b/actions/patch.vpn.ipsec_proposals.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.vpn.l2vpn_terminations.yaml
+++ b/actions/patch.vpn.l2vpn_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   l2vpn:

--- a/actions/patch.vpn.l2vpns.yaml
+++ b/actions/patch.vpn.l2vpns.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   identifier:

--- a/actions/patch.vpn.tunnel_groups.yaml
+++ b/actions/patch.vpn.tunnel_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.vpn.tunnel_terminations.yaml
+++ b/actions/patch.vpn.tunnel_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   tunnel:

--- a/actions/patch.vpn.tunnels.yaml
+++ b/actions/patch.vpn.tunnels.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.wireless.wireless_lan_groups.yaml
+++ b/actions/patch.wireless.wireless_lan_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/patch.wireless.wireless_lans.yaml
+++ b/actions/patch.wireless.wireless_lans.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   ssid:

--- a/actions/patch.wireless.wireless_links.yaml
+++ b/actions/patch.wireless.wireless_links.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   interface_a:

--- a/actions/post.circuits.circuit_group_assignments.yaml
+++ b/actions/post.circuits.circuit_group_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   group:

--- a/actions/post.circuits.circuit_groups.yaml
+++ b/actions/post.circuits.circuit_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.circuits.circuit_terminations.yaml
+++ b/actions/post.circuits.circuit_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   circuit:

--- a/actions/post.circuits.circuit_types.yaml
+++ b/actions/post.circuits.circuit_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.circuits.circuits.yaml
+++ b/actions/post.circuits.circuits.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cid:

--- a/actions/post.circuits.provider_accounts.yaml
+++ b/actions/post.circuits.provider_accounts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   provider:

--- a/actions/post.circuits.provider_networks.yaml
+++ b/actions/post.circuits.provider_networks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   provider:

--- a/actions/post.circuits.providers.yaml
+++ b/actions/post.circuits.providers.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.circuits.virtual_circuit_terminations.yaml
+++ b/actions/post.circuits.virtual_circuit_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   virtual_circuit:

--- a/actions/post.circuits.virtual_circuit_types.yaml
+++ b/actions/post.circuits.virtual_circuit_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.circuits.virtual_circuits.yaml
+++ b/actions/post.circuits.virtual_circuits.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cid:

--- a/actions/post.core.data_sources.yaml
+++ b/actions/post.core.data_sources.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.cable_terminations.yaml
+++ b/actions/post.dcim.cable_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cable:

--- a/actions/post.dcim.cables.yaml
+++ b/actions/post.dcim.cables.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   type:

--- a/actions/post.dcim.console_port_templates.yaml
+++ b/actions/post.dcim.console_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/post.dcim.console_ports.yaml
+++ b/actions/post.dcim.console_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/post.dcim.console_server_port_templates.yaml
+++ b/actions/post.dcim.console_server_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/post.dcim.console_server_ports.yaml
+++ b/actions/post.dcim.console_server_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/post.dcim.device_bay_templates.yaml
+++ b/actions/post.dcim.device_bay_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/post.dcim.device_bays.yaml
+++ b/actions/post.dcim.device_bays.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/post.dcim.device_roles.yaml
+++ b/actions/post.dcim.device_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.device_types.yaml
+++ b/actions/post.dcim.device_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   manufacturer:

--- a/actions/post.dcim.devices.yaml
+++ b/actions/post.dcim.devices.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.front_port_templates.yaml
+++ b/actions/post.dcim.front_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/post.dcim.front_ports.yaml
+++ b/actions/post.dcim.front_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/post.dcim.interface_templates.yaml
+++ b/actions/post.dcim.interface_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/post.dcim.interfaces.yaml
+++ b/actions/post.dcim.interfaces.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/post.dcim.inventory_item_roles.yaml
+++ b/actions/post.dcim.inventory_item_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.inventory_item_templates.yaml
+++ b/actions/post.dcim.inventory_item_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/post.dcim.inventory_items.yaml
+++ b/actions/post.dcim.inventory_items.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/post.dcim.locations.yaml
+++ b/actions/post.dcim.locations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.mac_addresses.yaml
+++ b/actions/post.dcim.mac_addresses.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   mac_address:

--- a/actions/post.dcim.manufacturers.yaml
+++ b/actions/post.dcim.manufacturers.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.module_bay_templates.yaml
+++ b/actions/post.dcim.module_bay_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/post.dcim.module_bays.yaml
+++ b/actions/post.dcim.module_bays.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/post.dcim.module_type_profiles.yaml
+++ b/actions/post.dcim.module_type_profiles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.module_types.yaml
+++ b/actions/post.dcim.module_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   profile:

--- a/actions/post.dcim.modules.yaml
+++ b/actions/post.dcim.modules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/post.dcim.platforms.yaml
+++ b/actions/post.dcim.platforms.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.power_feeds.yaml
+++ b/actions/post.dcim.power_feeds.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   power_panel:

--- a/actions/post.dcim.power_outlet_templates.yaml
+++ b/actions/post.dcim.power_outlet_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/post.dcim.power_outlets.yaml
+++ b/actions/post.dcim.power_outlets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/post.dcim.power_panels.yaml
+++ b/actions/post.dcim.power_panels.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   site:

--- a/actions/post.dcim.power_port_templates.yaml
+++ b/actions/post.dcim.power_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/post.dcim.power_ports.yaml
+++ b/actions/post.dcim.power_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/post.dcim.rack_reservations.yaml
+++ b/actions/post.dcim.rack_reservations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   rack:

--- a/actions/post.dcim.rack_roles.yaml
+++ b/actions/post.dcim.rack_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.rack_types.yaml
+++ b/actions/post.dcim.rack_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   manufacturer:

--- a/actions/post.dcim.racks.yaml
+++ b/actions/post.dcim.racks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.rear_port_templates.yaml
+++ b/actions/post.dcim.rear_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/post.dcim.rear_ports.yaml
+++ b/actions/post.dcim.rear_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/post.dcim.regions.yaml
+++ b/actions/post.dcim.regions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.site_groups.yaml
+++ b/actions/post.dcim.site_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.sites.yaml
+++ b/actions/post.dcim.sites.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.virtual_chassis.yaml
+++ b/actions/post.dcim.virtual_chassis.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.dcim.virtual_device_contexts.yaml
+++ b/actions/post.dcim.virtual_device_contexts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.extras.bookmarks.yaml
+++ b/actions/post.extras.bookmarks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/post.extras.config_contexts.yaml
+++ b/actions/post.extras.config_contexts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.extras.config_templates.yaml
+++ b/actions/post.extras.config_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.extras.custom_field_choice_sets.yaml
+++ b/actions/post.extras.custom_field_choice_sets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.extras.custom_fields.yaml
+++ b/actions/post.extras.custom_fields.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/post.extras.custom_links.yaml
+++ b/actions/post.extras.custom_links.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/post.extras.event_rules.yaml
+++ b/actions/post.extras.event_rules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/post.extras.export_templates.yaml
+++ b/actions/post.extras.export_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/post.extras.image_attachments.yaml
+++ b/actions/post.extras.image_attachments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/post.extras.journal_entries.yaml
+++ b/actions/post.extras.journal_entries.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   assigned_object_type:

--- a/actions/post.extras.notification_groups.yaml
+++ b/actions/post.extras.notification_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.extras.notifications.yaml
+++ b/actions/post.extras.notifications.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/post.extras.saved_filters.yaml
+++ b/actions/post.extras.saved_filters.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/post.extras.scripts.yaml
+++ b/actions/post.extras.scripts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
 runner_type: python-script

--- a/actions/post.extras.subscriptions.yaml
+++ b/actions/post.extras.subscriptions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/post.extras.table_configs.yaml
+++ b/actions/post.extras.table_configs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/post.extras.tags.yaml
+++ b/actions/post.extras.tags.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.extras.webhooks.yaml
+++ b/actions/post.extras.webhooks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.ipam.aggregates.yaml
+++ b/actions/post.ipam.aggregates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   prefix:

--- a/actions/post.ipam.asn_ranges.yaml
+++ b/actions/post.ipam.asn_ranges.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.ipam.asns.yaml
+++ b/actions/post.ipam.asns.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   asn:

--- a/actions/post.ipam.fhrp_group_assignments.yaml
+++ b/actions/post.ipam.fhrp_group_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   group:

--- a/actions/post.ipam.fhrp_groups.yaml
+++ b/actions/post.ipam.fhrp_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.ipam.ip_addresses.yaml
+++ b/actions/post.ipam.ip_addresses.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   address:

--- a/actions/post.ipam.ip_ranges.yaml
+++ b/actions/post.ipam.ip_ranges.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   start_address:

--- a/actions/post.ipam.prefixes.yaml
+++ b/actions/post.ipam.prefixes.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   prefix:

--- a/actions/post.ipam.rirs.yaml
+++ b/actions/post.ipam.rirs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.ipam.roles.yaml
+++ b/actions/post.ipam.roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.ipam.route_targets.yaml
+++ b/actions/post.ipam.route_targets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.ipam.service_templates.yaml
+++ b/actions/post.ipam.service_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.ipam.services.yaml
+++ b/actions/post.ipam.services.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   parent_object_type:

--- a/actions/post.ipam.vlan_groups.yaml
+++ b/actions/post.ipam.vlan_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.ipam.vlan_translation_policies.yaml
+++ b/actions/post.ipam.vlan_translation_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.ipam.vlan_translation_rules.yaml
+++ b/actions/post.ipam.vlan_translation_rules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   policy:

--- a/actions/post.ipam.vlans.yaml
+++ b/actions/post.ipam.vlans.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   site:

--- a/actions/post.ipam.vrfs.yaml
+++ b/actions/post.ipam.vrfs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.tenancy.contact_assignments.yaml
+++ b/actions/post.tenancy.contact_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/post.tenancy.contact_groups.yaml
+++ b/actions/post.tenancy.contact_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.tenancy.contact_roles.yaml
+++ b/actions/post.tenancy.contact_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.tenancy.contacts.yaml
+++ b/actions/post.tenancy.contacts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   groups:

--- a/actions/post.tenancy.tenant_groups.yaml
+++ b/actions/post.tenancy.tenant_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.tenancy.tenants.yaml
+++ b/actions/post.tenancy.tenants.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.users.groups.yaml
+++ b/actions/post.users.groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.users.permissions.yaml
+++ b/actions/post.users.permissions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.users.tokens.provision.yaml
+++ b/actions/post.users.tokens.provision.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   expires:

--- a/actions/post.users.tokens.yaml
+++ b/actions/post.users.tokens.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   user:

--- a/actions/post.users.users.yaml
+++ b/actions/post.users.users.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   username:

--- a/actions/post.virtualization.cluster_groups.yaml
+++ b/actions/post.virtualization.cluster_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.virtualization.cluster_types.yaml
+++ b/actions/post.virtualization.cluster_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.virtualization.clusters.yaml
+++ b/actions/post.virtualization.clusters.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.virtualization.interfaces.yaml
+++ b/actions/post.virtualization.interfaces.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   virtual_machine:

--- a/actions/post.virtualization.virtual_disks.yaml
+++ b/actions/post.virtualization.virtual_disks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   virtual_machine:

--- a/actions/post.virtualization.virtual_machines.yaml
+++ b/actions/post.virtualization.virtual_machines.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.vpn.ike_policies.yaml
+++ b/actions/post.vpn.ike_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.vpn.ike_proposals.yaml
+++ b/actions/post.vpn.ike_proposals.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.vpn.ipsec_policies.yaml
+++ b/actions/post.vpn.ipsec_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.vpn.ipsec_profiles.yaml
+++ b/actions/post.vpn.ipsec_profiles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.vpn.ipsec_proposals.yaml
+++ b/actions/post.vpn.ipsec_proposals.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.vpn.l2vpn_terminations.yaml
+++ b/actions/post.vpn.l2vpn_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   l2vpn:

--- a/actions/post.vpn.l2vpns.yaml
+++ b/actions/post.vpn.l2vpns.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   identifier:

--- a/actions/post.vpn.tunnel_groups.yaml
+++ b/actions/post.vpn.tunnel_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.vpn.tunnel_terminations.yaml
+++ b/actions/post.vpn.tunnel_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   tunnel:

--- a/actions/post.vpn.tunnels.yaml
+++ b/actions/post.vpn.tunnels.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.wireless.wireless_lan_groups.yaml
+++ b/actions/post.wireless.wireless_lan_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/post.wireless.wireless_lans.yaml
+++ b/actions/post.wireless.wireless_lans.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   ssid:

--- a/actions/post.wireless.wireless_links.yaml
+++ b/actions/post.wireless.wireless_links.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   interface_a:

--- a/actions/put.circuits.circuit_group_assignments.yaml
+++ b/actions/put.circuits.circuit_group_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   group:

--- a/actions/put.circuits.circuit_groups.yaml
+++ b/actions/put.circuits.circuit_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.circuits.circuit_terminations.yaml
+++ b/actions/put.circuits.circuit_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   circuit:

--- a/actions/put.circuits.circuit_types.yaml
+++ b/actions/put.circuits.circuit_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.circuits.circuits.yaml
+++ b/actions/put.circuits.circuits.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cid:

--- a/actions/put.circuits.provider_accounts.yaml
+++ b/actions/put.circuits.provider_accounts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   provider:

--- a/actions/put.circuits.provider_networks.yaml
+++ b/actions/put.circuits.provider_networks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   provider:

--- a/actions/put.circuits.providers.yaml
+++ b/actions/put.circuits.providers.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.circuits.virtual_circuit_terminations.yaml
+++ b/actions/put.circuits.virtual_circuit_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   virtual_circuit:

--- a/actions/put.circuits.virtual_circuit_types.yaml
+++ b/actions/put.circuits.virtual_circuit_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.circuits.virtual_circuits.yaml
+++ b/actions/put.circuits.virtual_circuits.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cid:

--- a/actions/put.core.data_sources.yaml
+++ b/actions/put.core.data_sources.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.cable_terminations.yaml
+++ b/actions/put.dcim.cable_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   cable:

--- a/actions/put.dcim.cables.yaml
+++ b/actions/put.dcim.cables.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   type:

--- a/actions/put.dcim.console_port_templates.yaml
+++ b/actions/put.dcim.console_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/put.dcim.console_ports.yaml
+++ b/actions/put.dcim.console_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/put.dcim.console_server_port_templates.yaml
+++ b/actions/put.dcim.console_server_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/put.dcim.console_server_ports.yaml
+++ b/actions/put.dcim.console_server_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/put.dcim.device_bay_templates.yaml
+++ b/actions/put.dcim.device_bay_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/put.dcim.device_bays.yaml
+++ b/actions/put.dcim.device_bays.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/put.dcim.device_roles.yaml
+++ b/actions/put.dcim.device_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.device_types.yaml
+++ b/actions/put.dcim.device_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   manufacturer:

--- a/actions/put.dcim.devices.yaml
+++ b/actions/put.dcim.devices.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.front_port_templates.yaml
+++ b/actions/put.dcim.front_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/put.dcim.front_ports.yaml
+++ b/actions/put.dcim.front_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/put.dcim.interface_templates.yaml
+++ b/actions/put.dcim.interface_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/put.dcim.interfaces.yaml
+++ b/actions/put.dcim.interfaces.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/put.dcim.inventory_item_roles.yaml
+++ b/actions/put.dcim.inventory_item_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.inventory_item_templates.yaml
+++ b/actions/put.dcim.inventory_item_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/put.dcim.inventory_items.yaml
+++ b/actions/put.dcim.inventory_items.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/put.dcim.locations.yaml
+++ b/actions/put.dcim.locations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.mac_addresses.yaml
+++ b/actions/put.dcim.mac_addresses.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   mac_address:

--- a/actions/put.dcim.manufacturers.yaml
+++ b/actions/put.dcim.manufacturers.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.module_bay_templates.yaml
+++ b/actions/put.dcim.module_bay_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/put.dcim.module_bays.yaml
+++ b/actions/put.dcim.module_bays.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/put.dcim.module_type_profiles.yaml
+++ b/actions/put.dcim.module_type_profiles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.module_types.yaml
+++ b/actions/put.dcim.module_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   profile:

--- a/actions/put.dcim.modules.yaml
+++ b/actions/put.dcim.modules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/put.dcim.platforms.yaml
+++ b/actions/put.dcim.platforms.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.power_feeds.yaml
+++ b/actions/put.dcim.power_feeds.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   power_panel:

--- a/actions/put.dcim.power_outlet_templates.yaml
+++ b/actions/put.dcim.power_outlet_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/put.dcim.power_outlets.yaml
+++ b/actions/put.dcim.power_outlets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/put.dcim.power_panels.yaml
+++ b/actions/put.dcim.power_panels.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   site:

--- a/actions/put.dcim.power_port_templates.yaml
+++ b/actions/put.dcim.power_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/put.dcim.power_ports.yaml
+++ b/actions/put.dcim.power_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/put.dcim.rack_reservations.yaml
+++ b/actions/put.dcim.rack_reservations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   rack:

--- a/actions/put.dcim.rack_roles.yaml
+++ b/actions/put.dcim.rack_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.rack_types.yaml
+++ b/actions/put.dcim.rack_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   manufacturer:

--- a/actions/put.dcim.racks.yaml
+++ b/actions/put.dcim.racks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.rear_port_templates.yaml
+++ b/actions/put.dcim.rear_port_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device_type:

--- a/actions/put.dcim.rear_ports.yaml
+++ b/actions/put.dcim.rear_ports.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   device:

--- a/actions/put.dcim.regions.yaml
+++ b/actions/put.dcim.regions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.site_groups.yaml
+++ b/actions/put.dcim.site_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.sites.yaml
+++ b/actions/put.dcim.sites.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.virtual_chassis.yaml
+++ b/actions/put.dcim.virtual_chassis.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.dcim.virtual_device_contexts.yaml
+++ b/actions/put.dcim.virtual_device_contexts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.extras.bookmarks.yaml
+++ b/actions/put.extras.bookmarks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/put.extras.config_contexts.yaml
+++ b/actions/put.extras.config_contexts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.extras.config_templates.yaml
+++ b/actions/put.extras.config_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.extras.custom_field_choice_sets.yaml
+++ b/actions/put.extras.custom_field_choice_sets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.extras.custom_fields.yaml
+++ b/actions/put.extras.custom_fields.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/put.extras.custom_links.yaml
+++ b/actions/put.extras.custom_links.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/put.extras.dashboard.yaml
+++ b/actions/put.extras.dashboard.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   layout:

--- a/actions/put.extras.event_rules.yaml
+++ b/actions/put.extras.event_rules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/put.extras.export_templates.yaml
+++ b/actions/put.extras.export_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/put.extras.image_attachments.yaml
+++ b/actions/put.extras.image_attachments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/put.extras.journal_entries.yaml
+++ b/actions/put.extras.journal_entries.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   assigned_object_type:

--- a/actions/put.extras.notification_groups.yaml
+++ b/actions/put.extras.notification_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.extras.notifications.yaml
+++ b/actions/put.extras.notifications.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/put.extras.saved_filters.yaml
+++ b/actions/put.extras.saved_filters.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_types:

--- a/actions/put.extras.scripts.yaml
+++ b/actions/put.extras.scripts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   data:

--- a/actions/put.extras.subscriptions.yaml
+++ b/actions/put.extras.subscriptions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/put.extras.table_configs.yaml
+++ b/actions/put.extras.table_configs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/put.extras.tags.yaml
+++ b/actions/put.extras.tags.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.extras.webhooks.yaml
+++ b/actions/put.extras.webhooks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.ipam.aggregates.yaml
+++ b/actions/put.ipam.aggregates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   prefix:

--- a/actions/put.ipam.asn_ranges.yaml
+++ b/actions/put.ipam.asn_ranges.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.ipam.asns.yaml
+++ b/actions/put.ipam.asns.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   asn:

--- a/actions/put.ipam.fhrp_group_assignments.yaml
+++ b/actions/put.ipam.fhrp_group_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   group:

--- a/actions/put.ipam.fhrp_groups.yaml
+++ b/actions/put.ipam.fhrp_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.ipam.ip_addresses.yaml
+++ b/actions/put.ipam.ip_addresses.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   address:

--- a/actions/put.ipam.ip_ranges.yaml
+++ b/actions/put.ipam.ip_ranges.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   start_address:

--- a/actions/put.ipam.prefixes.yaml
+++ b/actions/put.ipam.prefixes.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   prefix:

--- a/actions/put.ipam.rirs.yaml
+++ b/actions/put.ipam.rirs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.ipam.roles.yaml
+++ b/actions/put.ipam.roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.ipam.route_targets.yaml
+++ b/actions/put.ipam.route_targets.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.ipam.service_templates.yaml
+++ b/actions/put.ipam.service_templates.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.ipam.services.yaml
+++ b/actions/put.ipam.services.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   parent_object_type:

--- a/actions/put.ipam.vlan_groups.yaml
+++ b/actions/put.ipam.vlan_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.ipam.vlan_translation_policies.yaml
+++ b/actions/put.ipam.vlan_translation_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.ipam.vlan_translation_rules.yaml
+++ b/actions/put.ipam.vlan_translation_rules.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   policy:

--- a/actions/put.ipam.vlans.yaml
+++ b/actions/put.ipam.vlans.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   site:

--- a/actions/put.ipam.vrfs.yaml
+++ b/actions/put.ipam.vrfs.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.tenancy.contact_assignments.yaml
+++ b/actions/put.tenancy.contact_assignments.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   object_type:

--- a/actions/put.tenancy.contact_groups.yaml
+++ b/actions/put.tenancy.contact_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.tenancy.contact_roles.yaml
+++ b/actions/put.tenancy.contact_roles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.tenancy.contacts.yaml
+++ b/actions/put.tenancy.contacts.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   groups:

--- a/actions/put.tenancy.tenant_groups.yaml
+++ b/actions/put.tenancy.tenant_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.tenancy.tenants.yaml
+++ b/actions/put.tenancy.tenants.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.users.groups.yaml
+++ b/actions/put.users.groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.users.permissions.yaml
+++ b/actions/put.users.permissions.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.users.tokens.yaml
+++ b/actions/put.users.tokens.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   user:

--- a/actions/put.users.users.yaml
+++ b/actions/put.users.users.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   username:

--- a/actions/put.virtualization.cluster_groups.yaml
+++ b/actions/put.virtualization.cluster_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.virtualization.cluster_types.yaml
+++ b/actions/put.virtualization.cluster_types.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.virtualization.clusters.yaml
+++ b/actions/put.virtualization.clusters.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.virtualization.interfaces.yaml
+++ b/actions/put.virtualization.interfaces.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   virtual_machine:

--- a/actions/put.virtualization.virtual_disks.yaml
+++ b/actions/put.virtualization.virtual_disks.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   virtual_machine:

--- a/actions/put.virtualization.virtual_machines.yaml
+++ b/actions/put.virtualization.virtual_machines.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.vpn.ike_policies.yaml
+++ b/actions/put.vpn.ike_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.vpn.ike_proposals.yaml
+++ b/actions/put.vpn.ike_proposals.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.vpn.ipsec_policies.yaml
+++ b/actions/put.vpn.ipsec_policies.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.vpn.ipsec_profiles.yaml
+++ b/actions/put.vpn.ipsec_profiles.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.vpn.ipsec_proposals.yaml
+++ b/actions/put.vpn.ipsec_proposals.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.vpn.l2vpn_terminations.yaml
+++ b/actions/put.vpn.l2vpn_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   l2vpn:

--- a/actions/put.vpn.l2vpns.yaml
+++ b/actions/put.vpn.l2vpns.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   identifier:

--- a/actions/put.vpn.tunnel_groups.yaml
+++ b/actions/put.vpn.tunnel_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.vpn.tunnel_terminations.yaml
+++ b/actions/put.vpn.tunnel_terminations.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   tunnel:

--- a/actions/put.vpn.tunnels.yaml
+++ b/actions/put.vpn.tunnels.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.wireless.wireless_lan_groups.yaml
+++ b/actions/put.wireless.wireless_lan_groups.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   name:

--- a/actions/put.wireless.wireless_lans.yaml
+++ b/actions/put.wireless.wireless_lans.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   ssid:

--- a/actions/put.wireless.wireless_links.yaml
+++ b/actions/put.wireless.wireless_links.yaml
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   interface_a:

--- a/actions/run.py
+++ b/actions/run.py
@@ -10,10 +10,17 @@ class NetboxHTTPAction(NetboxBaseAction):
     Action to call netbox api and return response.
     """
 
-    def run(self, endpoint_uri, http_verb, get_detail_route_eligible, fail_non_2xx, **kwargs):
+    def run(self, endpoint_uri, http_verb, get_detail_route_eligible, fail_non_2xx=None, **kwargs):
         """
         StackStorm action entry point.
         """
+        # Determine effective fail_non_2xx behavior:
+        # - If the caller explicitly provided fail_non_2xx (True/False), honor that.
+        # - Otherwise, fall back to the pack-level default_fail_non_2xx config option (default False).
+        if fail_non_2xx is None:
+            effective_fail_non_2xx = self.config.get("default_fail_non_2xx", False)
+        else:
+            effective_fail_non_2xx = fail_non_2xx
         if http_verb == "get":
             if kwargs.get("id", False) and get_detail_route_eligible:
                 # modify the `endpoint_uri` to use the detail route
@@ -27,7 +34,7 @@ class NetboxHTTPAction(NetboxBaseAction):
 
             result = self.make_request(endpoint_uri, http_verb, **kwargs)
 
-            if fail_non_2xx:
+            if effective_fail_non_2xx:
                 # Return error rather than storing it in the keystone.
                 if result["status"] not in range(200, 300):
                     return (False, result)
@@ -53,7 +60,7 @@ class NetboxHTTPAction(NetboxBaseAction):
         # http return code is not 2xx.
         action_succeeded = True
 
-        if fail_non_2xx:
+        if effective_fail_non_2xx:
             action_succeeded = result.get("status") in range(200, 300)
 
         return (action_succeeded, result)

--- a/bin/action-template.jinja2
+++ b/bin/action-template.jinja2
@@ -18,7 +18,6 @@ parameters:
     immutable: true
     type: boolean
   fail_non_2xx:
-    default: false
     type: boolean
     description: Set action as failed when http return reponse status isn't 2xx.
   {%- for parameter in parameters %}

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -20,6 +20,12 @@ ssl_verify:
   type: "boolean"
   required: true
 
+default_fail_non_2xx:
+  description: "Default behavior for NetBox HTTP actions: when true, actions will fail on non-2xx NetBox responses unless the per-action fail_non_2xx parameter is explicitly set."
+  type: "boolean"
+  required: false
+  default: false
+
 sensor_address:
   description: "Host address to run the Webhook sensor on."
   type: "string"


### PR DESCRIPTION
Add a pack-level configuration option to control whether NetBox actions should fail when NetBox returns a non-2xx HTTP status, while keeping the existing per-action fail_non_2xx parameter as an explicit override.
